### PR TITLE
Update regex to correctly match puppet parser validate output.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,5 +19,5 @@ class Puppet(Linter):
 
     syntax = 'puppet'
     cmd = ('puppet', 'parser', 'validate', '--color=false')
-    regex = r'^Error:.+?(?P<message>Syntax error at \'(?P<near>.+?)\'?(?P<line>\d+):?(?P<col>\d+))'
+    regex = r'^Error:.+?(?P<message>Syntax error at \'(?P<near>.*?)\' \(line: (?P<line>\d+), column: (?P<col>\d+)\))'
     error_stream = util.STREAM_STDERR


### PR DESCRIPTION
The existing regex in the linter.py file doesn't correctly match puppet's validator output. The named capture groups weren't getting the right info, so the linter marks were always in the wrong place for me.

Examples here:

Current, non-working regex: https://regex101.com/r/Xk5edd/2
Working regex in pull request: https://regex101.com/r/Xk5edd/1

